### PR TITLE
Fix form input id and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 # POP Form
 
-This repository contains a simple HTML form for the Preoperative Protocol (POP) in Bulgarian. Open `pop-form.html` in your browser to use the form.
+This repository hosts a standalone HTML form used for the "Предоперативен протокол" (POP). It is a single‑page document and can be embedded in other sites such as WordPress.
+
+## Repository layout
+
+The project contains a few simple files:
+
+| File            | Purpose                                                   |
+|-----------------|-----------------------------------------------------------|
+| `pop-form.html` | The HTML form with TailwindCSS styling and a small script |
+| `README.md`     | Project documentation                                     |
+| `LICENSE`       | MIT license for the code                                   |
+
+Open `pop-form.html` directly in a browser to view and test the form. The form currently logs submitted values in the browser console.
+
+## Contributing
+
+Feel free to modify the HTML or script to connect it to a backend service (e.g. Google Sheets API) or to integrate it into a WordPress site.
 
 ## License
 

--- a/pop-form.html
+++ b/pop-form.html
@@ -21,9 +21,9 @@
             <label class="block text-sm font-medium text-gray-700" for="missionId">Номер / име на мисия <span class="text-red-500">*</span></label>
             <input type="text" id="missionId" name="missionId" required class="mt-1 w-full rounded-md border-gray-300" placeholder="01/10.07.25 пожар Долно Уйно"/>
           </div>
-         <div>
+        <div>
             <label class="block text-sm font-medium text-gray-700" for="mapLink">Линк към споделена CalTopo карта</label>
-            <input type="text" id="missionId" name="missionId" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
+            <input type="text" id="mapLink" name="mapLink" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
           </div>
           <div>
             <label class="block text-sm font-medium text-gray-700" for="leadName">Име на ръководител на терен <span class="text-red-500">*</span></label>
@@ -136,6 +136,7 @@
           e.preventDefault();
           const formData = new FormData(this);
           const entries = Object.fromEntries(formData.entries());
+          entries.risk = formData.getAll('risk');
           console.log('Форма данни:', entries);
           alert('Формулярът е попълнен успешно! (данните са в console.log)');
         });


### PR DESCRIPTION
## Summary
- fix duplicated `missionId` field id/name
- keep all selected `risk` values when reading form data
- document repo layout and usage in README

## Testing
- `npx --yes serve@latest` *(manual verification of form load)*

------
https://chatgpt.com/codex/tasks/task_e_686bd1959e9c833392916e54a0951bac