### PR TITLE
Add no-cors mode for fetch

### DIFF
--- a/pop-form.html
+++ b/pop-form.html
@@ -147,6 +147,7 @@
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify(entries),
+              mode: 'no-cors',
             })
               .then(() =>
                 alert('Формулярът е изпратен успешно!')


### PR DESCRIPTION
## Summary
- prevent CORS errors by adding `mode: 'no-cors'` to the fetch request in the form HTML

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686cb9510ea883338f812e997785e1f9