### PR TITLE
Add Google Apps Script web app sample

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,0 +1,38 @@
+function doGet() {
+  return HtmlService.createTemplateFromFile('Form').evaluate();
+}
+
+function include(filename) {
+  return HtmlService.createHtmlOutputFromFile(filename).getContent();
+}
+
+function handleForm(data) {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Form');
+  if (!sheet) {
+    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Form');
+  }
+  sheet.appendRow([
+    data.missionId,
+    data.mapLink,
+    data.leadName,
+    data.leadPhone,
+    data.lead2,
+    data.clubs,
+    data.missionType,
+    (data.risk || []).join(', '),
+    data.riskOtherText,
+    data.description,
+    data.rallyLocation,
+    data.rallyDateTime,
+    data.stateContact,
+    data.radio,
+    data.duration,
+    data.weather,
+    data.medical,
+    data.evac,
+    data.equipment,
+    data.attachment,
+    new Date()
+  ]);
+  return 'OK';
+}

--- a/apps-script/Form.html
+++ b/apps-script/Form.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ПОП – Предоперативен протокол (онлайн форма)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 py-8">
+    <div class="max-w-4xl mx-auto bg-white shadow-xl rounded-2xl p-8">
+      <h1 class="text-2xl font-bold mb-4 text-center">ПОП – Предоперативен протокол</h1>
+      <p class="mb-6 text-sm text-gray-600 text-center">
+                Подава се от ръководителя на терен <strong>преди</strong> стартиране на мисията. <br>
+                Препоръчва се да се попълва от член екипа, под консултация от капитан. <br>
+                Време за попълване: <U>под 5 минути</U>.
+      </p>
+      <form id="popForm" class="space-y-6">
+        <!-- Basic data -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="missionId">Номер / име на мисия <span class="text-red-500">*</span></label>
+            <input type="text" id="missionId" name="missionId" class="mt-1 w-full rounded-md border-gray-300" placeholder="01/10.07.25 пожар Долно Уйно"/>
+          </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700" for="mapLink">Линк към споделена CalTopo карта</label>
+            <input type="text" id="mapLink" name="mapLink" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadName">Име на ръководител на терен <span class="text-red-500">*</span></label>
+            <input type="text" id="leadName" name="leadName" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadPhone">Телефон на ръководителя <span class="text-red-500">*</span></label>
+            <input type="tel" id="leadPhone" name="leadPhone" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="lead2">Име на втори ръководител</label>
+            <input type="text" id="lead2" name="lead2" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="clubs">Клубове, които участват</label>
+            <input type="text" id="clubs" name="clubs" placeholder="СКБ 1, СКБ Хасково…" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+        </div>
+
+        <!-- Mission Type -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Тип мисия <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2">
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Издирване / SAR" class="h-4 w-4 text-indigo-600"><span class="ml-2">Издирване / SAR</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Пожар" class="h-4 w-4 text-indigo-600"><span class="ml-2">Пожар</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Наводнение" class="h-4 w-4 text-indigo-600"><span class="ml-2">Наводнение</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+        </fieldset>
+
+        <!-- Risk Assessment -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Оценка на риска <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2">
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Труден терен" class="h-4 w-4 text-indigo-600"><span class="ml-2">Труден терен</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Висока температура" class="h-4 w-4 text-indigo-600"><span class="ml-2">Висока температура</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Нощни действия" class="h-4 w-4 text-indigo-600"><span class="ml-2">Нощни действия</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Лоша видимост" class="h-4 w-4 text-indigo-600"><span class="ml-2">Лоша видимост</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Силен вятър" class="h-4 w-4 text-indigo-600"><span class="ml-2">Силен вятър</span></label>
+            <label class="inline-flex items-center"><input id="riskOther" type="checkbox" name="risk" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+          <input id="riskOtherText" type="text" name="riskOtherText" placeholder="Описание на допълнителния риск" class="mt-3 w-full rounded-md border-gray-300 hidden" />
+        </fieldset>
+
+        <!-- Free text fields -->
+        <div class="grid grid-cols-1 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="description">Кратко описание (цели, местоположение, анализ)</label>
+            <textarea id="description" name="description" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="пр. Овладяване на пожар в землището на село..., висок риск поради бурен вятър"></textarea>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyLocation">Локация на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="text" id="rallyLocation" name="rallyLocation" class="mt-1 w-full rounded-md border-gray-300" placeholder="координати, линк или описание" />
+            </div>
+                      <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyDateTime">Час и дата на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="datetime-local" id="rallyDateTime" name="rallyDateTime" class="mt-1 w-full rounded-md border-gray-300" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="stateContact">Държавен координатор (ПБЗН) - контакт</label>
+              <input type="text" id="stateContact" name="stateContact" class="mt-1 w-full rounded-md border-gray-300" placeholder="телефон"/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="radio">Радио честоти</label>
+              <input type="text" id="radio" name="radio" class="mt-1 w-full rounded-md border-gray-300" placeholder="432,625; 434,400" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="duration">Очаквана продължителност на акцията</label>
+              <input type="text" id="duration" name="duration" class="mt-1 w-full rounded-md border-gray-300" placeholder="максимум 24 ч."/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="weather">Метеорологична обстановка</label>
+              <textarea id="weather" name="weather" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="вятър, дъжд, температура"></textarea>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="medical">Медицинско осигуряване</label>
+              <textarea id="medical" name="medical" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Медицински лица на терен, медицински чанти..."></textarea>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="evac">Логистика за евакуация </label>
+              <textarea id="evac" name="evac" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Близък спешен център, евакуационен план"></textarea>
+            </div>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="equipment">Реквизиция на клубна екипировка <span class="text-red-500">*</span></label>
+            <textarea id="equipment" name="equipment" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="Превозни средства, мото-помпи, резачки…"></textarea>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="attachment">Приложение – списък с участници и подписи за инструктаж (отделен лист)</label>
+            <input type="text" id="attachment" name="attachment" class="mt-1 w-full rounded-md border-gray-300" placeholder="Прикачен файл / линк" />
+          </div>
+        </div>
+
+        <!-- Submit -->
+        <div class="pt-4">
+          <button type="submit" class="w-full md:w-auto px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази / изпрати</button>
+        </div>
+      </form>
+
+      <!-- Script to send form data to Google Sheets -->
+      <script>
+        document
+          .getElementById('popForm')
+          .addEventListener('submit', function (e) {
+            e.preventDefault();
+            const formData = new FormData(this);
+            const entries = Object.fromEntries(formData.entries());
+            entries.risk = formData.getAll('risk');
+
+            google.script.run
+              .withSuccessHandler(() =>
+                alert('Формулярът е изпратен успешно!')
+              )
+              .withFailureHandler((err) =>
+                alert('Грешка при изпращане: ' + err.message)
+              )
+              .handleForm(entries);
+          });
+
+        // Toggle other risk input visibility
+        const riskOtherCheckbox = document.getElementById('riskOther');
+        const riskOtherText = document.getElementById('riskOtherText');
+        riskOtherCheckbox.addEventListener('change', () => {
+          riskOtherText.classList.toggle('hidden', !riskOtherCheckbox.checked);
+        });
+      </script>
+    </div>
+  </body>
+</html>

--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -1,0 +1,17 @@
+# Google Apps Script Web App
+
+This folder contains a minimal example of using **HtmlService.createTemplateFromFile** to serve the POP form directly from Google Apps Script and store results in a Google Sheet.
+
+## Setup
+
+1. Open a new or existing Google Spreadsheet.
+2. Select **Extensions → Apps Script** to open the script editor.
+3. Create two files in the Apps Script project:
+   - **Code.gs** – server side logic (see `Code.gs` in this folder).
+   - **Form.html** – the HTML form template (see `Form.html`).
+4. Deploy the project as a **Web App** (Deploy → New deployment → Select "Web app").
+   - Execute as: `Me`
+   - Who has access: `Anyone`
+5. Open the provided URL to view the form. Submissions are appended to the spreadsheet.
+
+The form uses `google.script.run` to call the `handleForm` function, so no extra CORS configuration is required.


### PR DESCRIPTION
## Summary
- add Apps Script example with Code.gs and form template
- use `google.script.run` to save the form to Sheets

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest` *(runs: no tests ran)*
- `cargo test` *(fails: could not find `Cargo.toml`)*

------
https://chatgpt.com/codex/tasks/task_e_686cbadc44b08333b4953917726963aa