### PR TITLE
Add POP record manager

### DIFF
--- a/apps-script/Code.gs
+++ b/apps-script/Code.gs
@@ -1,5 +1,6 @@
-function doGet() {
-  return HtmlService.createTemplateFromFile('Form').evaluate();
+function doGet(e) {
+  var page = e && e.parameter.page === 'manager' ? 'Manager' : 'Form';
+  return HtmlService.createTemplateFromFile(page).evaluate();
 }
 
 function include(filename) {
@@ -35,4 +36,94 @@ function handleForm(data) {
     new Date()
   ]);
   return 'OK';
+}
+
+function getSheet() {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Form');
+  if (!sheet) {
+    sheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet('Form');
+  }
+  return sheet;
+}
+
+function listRecords() {
+  var sheet = getSheet();
+  var last = sheet.getLastRow();
+  var records = [];
+  for (var i = 1; i <= last; i++) {
+    var missionId = sheet.getRange(i, 1).getValue();
+    records.push({ row: i, missionId: missionId });
+  }
+  return records;
+}
+
+function getRecord(row) {
+  var sheet = getSheet();
+  var values = sheet.getRange(row, 1, 1, 21).getValues()[0];
+  return {
+    missionId: values[0],
+    mapLink: values[1],
+    leadName: values[2],
+    leadPhone: values[3],
+    lead2: values[4],
+    clubs: values[5],
+    missionType: values[6],
+    risk: (values[7] || '').split(/,\s*/),
+    riskOtherText: values[8],
+    description: values[9],
+    rallyLocation: values[10],
+    rallyDateTime: values[11],
+    stateContact: values[12],
+    radio: values[13],
+    duration: values[14],
+    weather: values[15],
+    medical: values[16],
+    evac: values[17],
+    equipment: values[18],
+    attachment: values[19],
+    timestamp: values[20]
+  };
+}
+
+function updateRecord(data) {
+  var sheet = getSheet();
+  var row = Number(data.row);
+  var values = [
+    data.missionId,
+    data.mapLink,
+    data.leadName,
+    data.leadPhone,
+    data.lead2,
+    data.clubs,
+    data.missionType,
+    (data.risk || []).join(', '),
+    data.riskOtherText,
+    data.description,
+    data.rallyLocation,
+    data.rallyDateTime,
+    data.stateContact,
+    data.radio,
+    data.duration,
+    data.weather,
+    data.medical,
+    data.evac,
+    data.equipment,
+    data.attachment,
+    sheet.getRange(row, 21).getValue()
+  ];
+  sheet.getRange(row, 1, 1, values.length).setValues([values]);
+  return 'OK';
+}
+
+function exportRecordPdf(row) {
+  var data = getRecord(row);
+  var doc = DocumentApp.create('POP Record ' + data.missionId);
+  var body = doc.getBody();
+  for (var key in data) {
+    body.appendParagraph(key + ': ' + data[key]);
+  }
+  doc.saveAndClose();
+  var pdf = DriveApp.getFileById(doc.getId()).getBlob();
+  DriveApp.getFileById(doc.getId()).setTrashed(true);
+  return Utilities.base64Encode(pdf.getBytes());
 }

--- a/apps-script/Form.html
+++ b/apps-script/Form.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ПОП – Предоперативен протокол (онлайн форма)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 py-8">
+    <div class="max-w-4xl mx-auto bg-white shadow-xl rounded-2xl p-8">
+      <h1 class="text-2xl font-bold mb-4 text-center">ПОП – Предоперативен протокол</h1>
+      <p class="mb-6 text-sm text-gray-600 text-center">
+                Подава се от ръководителя на терен <strong>преди</strong> стартиране на мисията. <br>
+                Препоръчва се да се попълва от член екипа, под консултация от капитан. <br>
+                Време за попълване: <U>под 5 минути</U>.
+      </p>
+      <form id="popForm" class="space-y-6">
+        <!-- Basic data -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="missionId">Номер / име на мисия <span class="text-red-500">*</span></label>
+            <input type="text" id="missionId" name="missionId" class="mt-1 w-full rounded-md border-gray-300" placeholder="01/10.07.25 пожар Долно Уйно"/>
+          </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700" for="mapLink">Линк към споделена CalTopo карта</label>
+            <input type="text" id="mapLink" name="mapLink" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadName">Име на ръководител на терен <span class="text-red-500">*</span></label>
+            <input type="text" id="leadName" name="leadName" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadPhone">Телефон на ръководителя <span class="text-red-500">*</span></label>
+            <input type="tel" id="leadPhone" name="leadPhone" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="lead2">Име на втори ръководител</label>
+            <input type="text" id="lead2" name="lead2" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="clubs">Клубове, които участват</label>
+            <input type="text" id="clubs" name="clubs" placeholder="СКБ 1, СКБ Хасково…" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+        </div>
+
+        <!-- Mission Type -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Тип мисия <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2">
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Издирване / SAR" class="h-4 w-4 text-indigo-600"><span class="ml-2">Издирване / SAR</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Пожар" class="h-4 w-4 text-indigo-600"><span class="ml-2">Пожар</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Наводнение" class="h-4 w-4 text-indigo-600"><span class="ml-2">Наводнение</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+        </fieldset>
+
+        <!-- Risk Assessment -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Оценка на риска <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2">
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Труден терен" class="h-4 w-4 text-indigo-600"><span class="ml-2">Труден терен</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Висока температура" class="h-4 w-4 text-indigo-600"><span class="ml-2">Висока температура</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Нощни действия" class="h-4 w-4 text-indigo-600"><span class="ml-2">Нощни действия</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Лоша видимост" class="h-4 w-4 text-indigo-600"><span class="ml-2">Лоша видимост</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Силен вятър" class="h-4 w-4 text-indigo-600"><span class="ml-2">Силен вятър</span></label>
+            <label class="inline-flex items-center"><input id="riskOther" type="checkbox" name="risk" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+          <input id="riskOtherText" type="text" name="riskOtherText" placeholder="Описание на допълнителния риск" class="mt-3 w-full rounded-md border-gray-300 hidden" />
+        </fieldset>
+
+        <!-- Free text fields -->
+        <div class="grid grid-cols-1 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="description">Кратко описание (цели, местоположение, анализ)</label>
+            <textarea id="description" name="description" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="пр. Овладяване на пожар в землището на село..., висок риск поради бурен вятър"></textarea>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyLocation">Локация на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="text" id="rallyLocation" name="rallyLocation" class="mt-1 w-full rounded-md border-gray-300" placeholder="координати, линк или описание" />
+            </div>
+                      <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyDateTime">Час и дата на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="datetime-local" id="rallyDateTime" name="rallyDateTime" class="mt-1 w-full rounded-md border-gray-300" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="stateContact">Държавен координатор (ПБЗН) - контакт</label>
+              <input type="text" id="stateContact" name="stateContact" class="mt-1 w-full rounded-md border-gray-300" placeholder="телефон"/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="radio">Радио честоти</label>
+              <input type="text" id="radio" name="radio" class="mt-1 w-full rounded-md border-gray-300" placeholder="432,625; 434,400" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="duration">Очаквана продължителност на акцията</label>
+              <input type="text" id="duration" name="duration" class="mt-1 w-full rounded-md border-gray-300" placeholder="максимум 24 ч."/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="weather">Метеорологична обстановка</label>
+              <textarea id="weather" name="weather" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="вятър, дъжд, температура"></textarea>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="medical">Медицинско осигуряване</label>
+              <textarea id="medical" name="medical" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Медицински лица на терен, медицински чанти..."></textarea>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="evac">Логистика за евакуация </label>
+              <textarea id="evac" name="evac" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Близък спешен център, евакуационен план"></textarea>
+            </div>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="equipment">Реквизиция на клубна екипировка <span class="text-red-500">*</span></label>
+            <textarea id="equipment" name="equipment" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="Превозни средства, мото-помпи, резачки…"></textarea>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="attachment">Приложение – списък с участници и подписи за инструктаж (отделен лист)</label>
+            <input type="text" id="attachment" name="attachment" class="mt-1 w-full rounded-md border-gray-300" placeholder="Прикачен файл / линк" />
+          </div>
+        </div>
+
+        <!-- Submit -->
+        <div class="pt-4">
+          <button type="submit" class="w-full md:w-auto px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази / изпрати</button>
+        </div>
+      </form>
+
+      <!-- Script to send form data to Google Sheets -->
+      <script>
+        document
+          .getElementById('popForm')
+          .addEventListener('submit', function (e) {
+            e.preventDefault();
+            const formData = new FormData(this);
+            const entries = Object.fromEntries(formData.entries());
+            entries.risk = formData.getAll('risk');
+
+            google.script.run
+              .withSuccessHandler(() =>
+                alert('Формулярът е изпратен успешно!')
+              )
+              .withFailureHandler((err) =>
+                alert('Грешка при изпращане: ' + err.message)
+              )
+              .handleForm(entries);
+          });
+
+        // Toggle other risk input visibility
+        const riskOtherCheckbox = document.getElementById('riskOther');
+        const riskOtherText = document.getElementById('riskOtherText');
+        riskOtherCheckbox.addEventListener('change', () => {
+          riskOtherText.classList.toggle('hidden', !riskOtherCheckbox.checked);
+        });
+      </script>
+    </div>
+  </body>
+</html>

--- a/apps-script/Manager.html
+++ b/apps-script/Manager.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ПОП – Мениджър</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 py-8">
+    <div class="max-w-4xl mx-auto bg-white shadow-xl rounded-2xl p-8">
+      <h1 class="text-2xl font-bold mb-4 text-center">Мениджър на ПОП записи</h1>
+      <div id="recordsList" class="mb-6"></div>
+      <form id="popForm" class="space-y-6 hidden">
+        <!-- Basic data -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="missionId">Номер / име на мисия <span class="text-red-500">*</span></label>
+            <input type="text" id="missionId" name="missionId" class="mt-1 w-full rounded-md border-gray-300" placeholder="01/10.07.25 пожар Долно Уйно"/>
+          </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700" for="mapLink">Линк към споделена CalTopo карта</label>
+            <input type="text" id="mapLink" name="mapLink" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadName">Име на ръководител на терен <span class="text-red-500">*</span></label>
+            <input type="text" id="leadName" name="leadName" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadPhone">Телефон на ръководителя <span class="text-red-500">*</span></label>
+            <input type="tel" id="leadPhone" name="leadPhone" class="mt-1 w-full  rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="lead2">Име на втори ръководител</label>
+            <input type="text" id="lead2" name="lead2" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="clubs">Клубове, които участват</label>
+            <input type="text" id="clubs" name="clubs" placeholder="СКБ 1, СКБ Хасково…" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+        </div>
+
+        <!-- Mission Type -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Тип мисия <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2">
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Издирване / SAR" class="h-4 w-4 text-indigo-600"><span class="ml-2">Издирване / SAR</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Пожар" class="h-4 w-4 text-indigo-600"><span class="ml-2">Пожар</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Наводнение" class="h-4 w-4 text-indigo-600"><span class="ml-2">Наводнение</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+        </fieldset>
+
+        <!-- Risk Assessment -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Оценка на риска <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2">
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Труден терен" class="h-4 w-4 text-indigo-600"><span class="ml-2">Труден терен</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Висока температура" class="h-4 w-4 text-indigo-600"><span class="ml-2">Висока температура</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Нощни действия" class="h-4 w-4 text-indigo-600"><span class="ml-2">Нощни действия</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Лоша видимост" class="h-4 w-4 text-indigo-600"><span class="ml-2">Лоша видимост</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Силен вятър" class="h-4 w-4 text-indigo-600"><span class="ml-2">Силен вятър</span></label>
+            <label class="inline-flex items-center"><input id="riskOther" type="checkbox" name="risk" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+          <input id="riskOtherText" type="text" name="riskOtherText" placeholder="Описание на допълнителния риск" class="mt-3 w-full rounded-md border-gray-300 hidden" />
+        </fieldset>
+
+        <!-- Free text fields -->
+        <div class="grid grid-cols-1 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="description">Кратко описание (цели, местоположение, анализ)</label>
+            <textarea id="description" name="description" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="пр. Овладяване на пожар в землището на село..., висок риск поради бурен вятър"></textarea>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyLocation">Локация на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="text" id="rallyLocation" name="rallyLocation" class="mt-1 w-full rounded-md border-gray-300" placeholder="координати, линк или описание" />
+            </div>
+                      <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyDateTime">Час и дата на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="datetime-local" id="rallyDateTime" name="rallyDateTime" class="mt-1 w-full rounded-md border-gray-300" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="stateContact">Държавен координатор (ПБЗН) - контакт</label>
+              <input type="text" id="stateContact" name="stateContact" class="mt-1 w-full rounded-md border-gray-300" placeholder="телефон"/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="radio">Радио честоти</label>
+              <input type="text" id="radio" name="radio" class="mt-1 w-full rounded-md border-gray-300" placeholder="432,625; 434,400" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="duration">Очаквана продължителност на акцията</label>
+              <input type="text" id="duration" name="duration" class="mt-1 w-full rounded-md border-gray-300" placeholder="максимум 24 ч."/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="weather">Метеорологична обстановка</label>
+              <textarea id="weather" name="weather" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="вятър, дъжд, температура"></textarea>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="medical">Медицинско осигуряване</label>
+              <textarea id="medical" name="medical" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Медицински лица на терен, медицински чанти..."></textarea>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="evac">Логистика за евакуация </label>
+              <textarea id="evac" name="evac" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Близък спешен център, евакуационен план"></textarea>
+            </div>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="equipment">Реквизиция на клубна екипировка <span class="text-red-500">*</span></label>
+            <textarea id="equipment" name="equipment" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="Превозни средства, мото-помпи, резачки…"></textarea>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="attachment">Приложение – списък с участници и подписи за инструктаж (отделен лист)</label>
+            <input type="text" id="attachment" name="attachment" class="mt-1 w-full rounded-md border-gray-300" placeholder="Прикачен файл / линк" />
+          </div>
+        </div>
+
+        <!-- Submit -->
+        <div class="pt-4">
+          <button type="submit" class="w-full md:w-auto px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази / изпрати</button>
+        </div>
+      </form>
+      <div class="flex gap-4 pt-4">
+        <button id="saveBtn" type="button" class="hidden px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази</button>
+        <button id="pdfBtn" type="button" class="hidden px-6 py-2 rounded-xl bg-gray-600 text-white font-semibold shadow hover:bg-gray-700 transition">PDF</button>
+      </div>
+      <script>
+        let currentRow = null;
+
+        function loadList() {
+          google.script.run.withSuccessHandler(list => {
+            const container = document.getElementById('recordsList');
+            container.innerHTML = '';
+            list.forEach(r => {
+              const btn = document.createElement('button');
+              btn.textContent = r.missionId + ' (#' + r.row + ')';
+              btn.className = 'block text-left w-full underline text-blue-600 mb-1';
+              btn.onclick = () => loadRecord(r.row);
+              container.appendChild(btn);
+            });
+          }).listRecords();
+        }
+
+        function loadRecord(row) {
+          google.script.run.withSuccessHandler(data => {
+            currentRow = row;
+            document.getElementById('popForm').classList.remove('hidden');
+            document.getElementById('saveBtn').classList.remove('hidden');
+            document.getElementById('pdfBtn').classList.remove('hidden');
+            for (const key in data) {
+              const field = document.querySelector('[name="' + key + '"]');
+              if (!field) continue;
+              if (field.type === 'radio') {
+                const radio = document.querySelector('[name="' + key + '"][value="' + data[key] + '"]');
+                if (radio) radio.checked = true;
+              } else if (field.type === 'checkbox') {
+                const values = Array.isArray(data[key]) ? data[key] : [data[key]];
+                document.querySelectorAll('[name="' + key + '"]').forEach(c => {
+                  c.checked = values.includes(c.value);
+                });
+              } else {
+                field.value = data[key];
+              }
+            }
+          }).getRecord(row);
+        }
+
+        document.getElementById('saveBtn').addEventListener('click', () => {
+          const formData = new FormData(document.getElementById('popForm'));
+          const entries = Object.fromEntries(formData.entries());
+          entries.risk = formData.getAll('risk');
+          entries.row = currentRow;
+          google.script.run.withSuccessHandler(() => {
+            alert('Записът е обновен');
+          }).updateRecord(entries);
+        });
+
+        document.getElementById('pdfBtn').addEventListener('click', () => {
+          google.script.run.withSuccessHandler(b64 => {
+            const link = document.createElement('a');
+            link.href = 'data:application/pdf;base64,' + b64;
+            link.download = 'record-' + currentRow + '.pdf';
+            link.click();
+          }).exportRecordPdf(currentRow);
+        });
+
+        const riskOtherCheckbox = document.getElementById('riskOther');
+        const riskOtherText = document.getElementById('riskOtherText');
+        riskOtherCheckbox.addEventListener('change', () => {
+          riskOtherText.classList.toggle('hidden', !riskOtherCheckbox.checked);
+        });
+
+        window.onload = loadList;
+      </script>
+    </div>
+  </body>
+</html>

--- a/apps-script/README.md
+++ b/apps-script/README.md
@@ -6,8 +6,10 @@ This folder contains a minimal example of using **HtmlService.createTemplateFrom
 
 1. Open a new or existing Google Spreadsheet.
 2. Select **Extensions → Apps Script** to open the script editor.
-3. Create two files in the Apps Script project:
+3. Create the following files in the Apps Script project:
    - **Code.gs** – server side logic (see `Code.gs` in this folder).
+   - **Form.html** – POP submission form.
+   - **Manager.html** – page for browsing and editing existing records.
 4. Deploy the project as a **Web App** (Deploy → New deployment → Select "Web app").
    - Execute as: `Me`
    - Who has access: `Anyone`

--- a/pop-manager.html
+++ b/pop-manager.html
@@ -1,0 +1,211 @@
+<!DOCTYPE html>
+<html lang="bg">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ПОП – Мениджър</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-gray-100 py-8">
+    <div class="max-w-4xl mx-auto bg-white shadow-xl rounded-2xl p-8">
+      <h1 class="text-2xl font-bold mb-4 text-center">Мениджър на ПОП записи</h1>
+      <div id="recordsList" class="mb-6"></div>
+      <form id="popForm" class="space-y-6 hidden">
+        <!-- Basic data -->
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="missionId">Номер / име на мисия <span class="text-red-500">*</span></label>
+            <input type="text" id="missionId" name="missionId" class="mt-1 w-full rounded-md border-gray-300" placeholder="01/10.07.25 пожар Долно Уйно"/>
+          </div>
+        <div>
+            <label class="block text-sm font-medium text-gray-700" for="mapLink">Линк към споделена CalTopo карта</label>
+            <input type="text" id="mapLink" name="mapLink" placeholder="карта с update права" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadName">Име на ръководител на терен <span class="text-red-500">*</span></label>
+            <input type="text" id="leadName" name="leadName" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="leadPhone">Телефон на ръководителя <span class="text-red-500">*</span></label>
+            <input type="tel" id="leadPhone" name="leadPhone" class="mt-1 w-full  rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="lead2">Име на втори ръководител</label>
+            <input type="text" id="lead2" name="lead2" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="clubs">Клубове, които участват</label>
+            <input type="text" id="clubs" name="clubs" placeholder="СКБ 1, СКБ Хасково…" class="mt-1 w-full rounded-md border-gray-300" />
+          </div>
+        </div>
+
+        <!-- Mission Type -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Тип мисия <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-4 gap-2">
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Издирване / SAR" class="h-4 w-4 text-indigo-600"><span class="ml-2">Издирване / SAR</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Пожар" class="h-4 w-4 text-indigo-600"><span class="ml-2">Пожар</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Наводнение" class="h-4 w-4 text-indigo-600"><span class="ml-2">Наводнение</span></label>
+            <label class="inline-flex items-center"><input type="radio" name="missionType" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+        </fieldset>
+
+        <!-- Risk Assessment -->
+        <fieldset>
+          <legend class="text-sm font-medium text-gray-700">Оценка на риска <span class="text-red-500">*</span></legend>
+          <div class="mt-2 grid grid-cols-2 md:grid-cols-3 gap-2">
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Труден терен" class="h-4 w-4 text-indigo-600"><span class="ml-2">Труден терен</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Висока температура" class="h-4 w-4 text-indigo-600"><span class="ml-2">Висока температура</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Нощни действия" class="h-4 w-4 text-indigo-600"><span class="ml-2">Нощни действия</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Лоша видимост" class="h-4 w-4 text-indigo-600"><span class="ml-2">Лоша видимост</span></label>
+            <label class="inline-flex items-center"><input type="checkbox" name="risk" value="Силен вятър" class="h-4 w-4 text-indigo-600"><span class="ml-2">Силен вятър</span></label>
+            <label class="inline-flex items-center"><input id="riskOther" type="checkbox" name="risk" value="Друго" class="h-4 w-4 text-indigo-600"><span class="ml-2">Друго</span></label>
+          </div>
+          <input id="riskOtherText" type="text" name="riskOtherText" placeholder="Описание на допълнителния риск" class="mt-3 w-full rounded-md border-gray-300 hidden" />
+        </fieldset>
+
+        <!-- Free text fields -->
+        <div class="grid grid-cols-1 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="description">Кратко описание (цели, местоположение, анализ)</label>
+            <textarea id="description" name="description" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="пр. Овладяване на пожар в землището на село..., висок риск поради бурен вятър"></textarea>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyLocation">Локация на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="text" id="rallyLocation" name="rallyLocation" class="mt-1 w-full rounded-md border-gray-300" placeholder="координати, линк или описание" />
+            </div>
+                      <div>
+              <label class="block text-sm font-medium text-gray-700" for="rallyDateTime">Час и дата на сборен пункт <span class="text-red-500">*</span></label>
+              <input type="datetime-local" id="rallyDateTime" name="rallyDateTime" class="mt-1 w-full rounded-md border-gray-300" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="stateContact">Държавен координатор (ПБЗН) - контакт</label>
+              <input type="text" id="stateContact" name="stateContact" class="mt-1 w-full rounded-md border-gray-300" placeholder="телефон"/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="radio">Радио честоти</label>
+              <input type="text" id="radio" name="radio" class="mt-1 w-full rounded-md border-gray-300" placeholder="432,625; 434,400" />
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="duration">Очаквана продължителност на акцията</label>
+              <input type="text" id="duration" name="duration" class="mt-1 w-full rounded-md border-gray-300" placeholder="максимум 24 ч."/>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="weather">Метеорологична обстановка</label>
+              <textarea id="weather" name="weather" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="вятър, дъжд, температура"></textarea>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="medical">Медицинско осигуряване</label>
+              <textarea id="medical" name="medical" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Медицински лица на терен, медицински чанти..."></textarea>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700" for="evac">Логистика за евакуация </label>
+              <textarea id="evac" name="evac" rows="2" class="mt-1 w-full rounded-md border-gray-300" placeholder="Близък спешен център, евакуационен план"></textarea>
+            </div>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="equipment">Реквизиция на клубна екипировка <span class="text-red-500">*</span></label>
+            <textarea id="equipment" name="equipment" rows="3" class="mt-1 w-full rounded-md border-gray-300" placeholder="Превозни средства, мото-помпи, резачки…"></textarea>
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700" for="attachment">Приложение – списък с участници и подписи за инструктаж (отделен лист)</label>
+            <input type="text" id="attachment" name="attachment" class="mt-1 w-full rounded-md border-gray-300" placeholder="Прикачен файл / линк" />
+          </div>
+        </div>
+
+        <!-- Submit -->
+        <div class="pt-4">
+          <button type="submit" class="w-full md:w-auto px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази / изпрати</button>
+        </div>
+      </form>
+      <div class="flex gap-4 pt-4">
+        <button id="saveBtn" type="button" class="hidden px-6 py-2 rounded-xl bg-indigo-600 text-white font-semibold shadow hover:bg-indigo-700 transition">Запази</button>
+        <button id="pdfBtn" type="button" class="hidden px-6 py-2 rounded-xl bg-gray-600 text-white font-semibold shadow hover:bg-gray-700 transition">PDF</button>
+      </div>
+      <script>
+        const scriptUrl = 'https://script.google.com/macros/s/AKfycbxlWVka1aTGF9fdt7jWoQafD4oilSQ2oRMjujCvcaxWhUZCUnUxDuVZh9gMwOXQpuv8Xw/exec';
+        let currentRow = null;
+
+        function loadList() {
+          fetch(scriptUrl + '?action=list')
+            .then(r => r.json())
+            .then(list => {
+              const container = document.getElementById('recordsList');
+              container.innerHTML = '';
+              list.forEach(r => {
+                const btn = document.createElement('button');
+                btn.textContent = r.missionId + ' (#' + r.row + ')';
+                btn.className = 'block text-left w-full underline text-blue-600 mb-1';
+                btn.onclick = () => loadRecord(r.row);
+                container.appendChild(btn);
+              });
+            });
+        }
+
+        function loadRecord(row) {
+          fetch(scriptUrl + '?action=get&row=' + row)
+            .then(r => r.json())
+            .then(data => {
+              currentRow = row;
+              document.getElementById('popForm').classList.remove('hidden');
+              document.getElementById('saveBtn').classList.remove('hidden');
+              document.getElementById('pdfBtn').classList.remove('hidden');
+              for (const key in data) {
+                const field = document.querySelector('[name="' + key + '"]');
+                if (!field) continue;
+                if (field.type === 'radio') {
+                  const radio = document.querySelector('[name="' + key + '"][value="' + data[key] + '"]');
+                  if (radio) radio.checked = true;
+                } else if (field.type === 'checkbox') {
+                  const values = Array.isArray(data[key]) ? data[key] : [data[key]];
+                  document.querySelectorAll('[name="' + key + '"]').forEach(c => {
+                    c.checked = values.includes(c.value);
+                  });
+                } else {
+                  field.value = data[key];
+                }
+              }
+            });
+        }
+
+        document.getElementById('saveBtn').addEventListener('click', () => {
+          const formData = new FormData(document.getElementById('popForm'));
+          const entries = Object.fromEntries(formData.entries());
+          entries.risk = formData.getAll('risk');
+          entries.row = currentRow;
+          fetch(scriptUrl + '?action=update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(entries)
+          }).then(() => alert('Записът е обновен'));
+        });
+
+        document.getElementById('pdfBtn').addEventListener('click', () => {
+          fetch(scriptUrl + '?action=pdf&row=' + currentRow)
+            .then(r => r.text())
+            .then(b64 => {
+              const link = document.createElement('a');
+              link.href = 'data:application/pdf;base64,' + b64;
+              link.download = 'record-' + currentRow + '.pdf';
+              link.click();
+            });
+        });
+
+        const riskOtherCheckbox = document.getElementById('riskOther');
+        const riskOtherText = document.getElementById('riskOtherText');
+        riskOtherCheckbox.addEventListener('change', () => {
+          riskOtherText.classList.toggle('hidden', !riskOtherCheckbox.checked);
+        });
+
+        window.onload = loadList;
+      </script>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- extend Apps Script to serve a manager page
- add APIs to list, fetch, update and export records
- add new `pop-manager.html` page to view and edit records
- restore `Form.html` and add `Manager.html` templates for the Web App

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ccf7c116083338668f0c22e6b1b1f